### PR TITLE
feat: actions/core upgraded to v1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/aws-actions/amazon-ecs-deploy-task-definition#readme",
   "dependencies": {
-    "@actions/core": "^1.2.6",
+    "@actions/core": "^1.10.0",
     "aws-sdk": "^2.710.0",
     "yaml": "^1.10.0"
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Following the recommendations from Github (https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) to remove the set-output warnings we propose to update the version of actions/core component.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
